### PR TITLE
Turbolinks in rails 7

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ gem "puma", ">= 5.0"
 gem "importmap-rails"
 
 # Hotwire's SPA-like page accelerator [https://turbo.hotwired.dev]
-gem "turbo-rails"
+# gem "turbo-rails"
 
 # Hotwire's modest JavaScript framework [https://stimulus.hotwired.dev]
 gem "stimulus-rails"

--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ gem "importmap-rails"
 
 # Hotwire's SPA-like page accelerator [https://turbo.hotwired.dev]
 # gem "turbo-rails"
+gem 'turbolinks'
 
 # Hotwire's modest JavaScript framework [https://stimulus.hotwired.dev]
 gem "stimulus-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -227,10 +227,6 @@ GEM
     stringio (3.1.0)
     thor (1.3.0)
     timeout (0.4.1)
-    turbo-rails (1.5.0)
-      actionpack (>= 6.0.0)
-      activejob (>= 6.0.0)
-      railties (>= 6.0.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     web-console (4.2.1)
@@ -267,7 +263,6 @@ DEPENDENCIES
   sprockets-rails
   sqlite3 (~> 1.4)
   stimulus-rails
-  turbo-rails
   tzinfo-data
   web-console
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -227,6 +227,9 @@ GEM
     stringio (3.1.0)
     thor (1.3.0)
     timeout (0.4.1)
+    turbolinks (5.2.1)
+      turbolinks-source (~> 5.2)
+    turbolinks-source (5.2.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     web-console (4.2.1)
@@ -263,6 +266,7 @@ DEPENDENCIES
   sprockets-rails
   sqlite3 (~> 1.4)
   stimulus-rails
+  turbolinks
   tzinfo-data
   web-console
 

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,3 +1,3 @@
 // Configure your import map in config/importmap.rb. Read more: https://github.com/rails/importmap-rails
-import "@hotwired/turbo-rails"
-import "controllers"
+// import "@hotwired/turbo-rails"
+// import "controllers"

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,3 +1,5 @@
 // Configure your import map in config/importmap.rb. Read more: https://github.com/rails/importmap-rails
 // import "@hotwired/turbo-rails"
 // import "controllers"
+import Turbolinks from "turbolinks";
+Turbolinks.start();

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -6,7 +6,7 @@
   <% @tasks.each do |task| %>
     <%= render task %>
     <p>
-      <%= link_to "Show this task", task %>
+      <%= link_to "Show this task", task, 'data-turbolinks': false %>
     </p>
   <% end %>
 </div>

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -1,7 +1,5 @@
 # Pin npm packages by running ./bin/importmap
 
 pin "application"
-pin "@hotwired/turbo-rails", to: "turbo.min.js", preload: true
-pin "@hotwired/stimulus", to: "stimulus.min.js"
 pin "@hotwired/stimulus-loading", to: "stimulus-loading.js"
 pin_all_from "app/javascript/controllers", under: "controllers"

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -2,4 +2,5 @@
 
 pin "application"
 pin "@hotwired/stimulus-loading", to: "stimulus-loading.js"
+pin "turbolinks", to: "https://ga.jspm.io/npm:turbolinks@5.2.0/dist/turbolinks.js"
 pin_all_from "app/javascript/controllers", under: "controllers"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,5 +7,5 @@ Rails.application.routes.draw do
   get "up" => "rails/health#show", as: :rails_health_check
 
   # Defines the root path route ("/")
-  # root "posts#index"
+  root "tasks#index"
 end


### PR DESCRIPTION
This PR is for confirming the compatibility of gem turbolinks in rails v7+, as we rails 7 uses turbo-rails gem by default now and turbolinks gem is now not in active development. We have to confirm the compatibility of this gem in rails v7 and upper, so I built a rails 7 project created a simple CRUD for task model with scaffold then remove the default `turbo-rails` gem from the app and install the `turbolinks` gem to make sure it is working as it should.

We are confirmed with this branch that application still can use turbolinks as it was using before. `turbo-rails` gem is just a upgraded version of `turbolinks` and rails 7 has it by default now as rails 6 was have `turbolinks` as default.
